### PR TITLE
Update redis package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/lukechilds/keyv-redis",
   "dependencies": {
     "pify": "3.0.0",
-    "redis": "2.8.0"
+    "redis": "^3.1.2"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
Update redis package to `3.1.2`.

All tests passing locally.


![Screenshot 2021-06-01 at 11 32 05 AM](https://user-images.githubusercontent.com/42499837/120274097-000f0280-c2cd-11eb-9bed-1483066f3e2c.png)